### PR TITLE
Use if (x in Group) instead of if (Group[x] === undefined)

### DIFF
--- a/Sledgehammer/Commands/General/Help.js
+++ b/Sledgehammer/Commands/General/Help.js
@@ -40,7 +40,7 @@ module.exports = {
 				let m = "```ini\n";
 				Sledgehammer.Commands.All.map((a) => {
 					let Group = Sledgehammer.Commands.Map[a];
-					if(x[Group] === undefined){
+					if(x in Group){
 						x[Group] = [];
 					}
 

--- a/Sledgehammer/Commands/General/Help.js
+++ b/Sledgehammer/Commands/General/Help.js
@@ -40,7 +40,7 @@ module.exports = {
 				let m = "```ini\n";
 				Sledgehammer.Commands.All.map((a) => {
 					let Group = Sledgehammer.Commands.Map[a];
-					if(Group in x){
+					if(!Group in x){
 						x[Group] = [];
 					}
 

--- a/Sledgehammer/Commands/General/Help.js
+++ b/Sledgehammer/Commands/General/Help.js
@@ -40,7 +40,7 @@ module.exports = {
 				let m = "```ini\n";
 				Sledgehammer.Commands.All.map((a) => {
 					let Group = Sledgehammer.Commands.Map[a];
-					if(x in Group){
+					if(Group in x){
 						x[Group] = [];
 					}
 


### PR DESCRIPTION
This is a much clearer method of handling, and no need for strict mode crap